### PR TITLE
Unsubscribe Method

### DIFF
--- a/lib/cordial/contacts.rb
+++ b/lib/cordial/contacts.rb
@@ -14,7 +14,7 @@ module Cordial
           email: {
             address: email
           }
-        },
+        }
       }.merge(attribute_list))
     end
   end

--- a/lib/cordial/contacts.rb
+++ b/lib/cordial/contacts.rb
@@ -17,5 +17,9 @@ module Cordial
         }
       }.merge(attribute_list))
     end
+
+    def self.unsubscribe(email:, channel: 'email')
+      client.put("/contacts/#{email}/unsubscribe/#{channel}")
+    end
   end
 end

--- a/spec/cordial/contacts_spec.rb
+++ b/spec/cordial/contacts_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Cordial::Contacts do
   let(:email) { 'cordial@example.com' }
@@ -12,19 +12,18 @@ RSpec.describe Cordial::Contacts do
   end
 
   describe '#create' do
-     subject { described_class.create(email: email, attribute_list: attribute_list) }
+    subject { described_class.create(email: email, attribute_list: attribute_list) }
 
-     let(:attribute_list) do
-       { first_name: 'Cordial' }
-     end
+    let(:attribute_list) do
+      { first_name: 'Cordial' }
+    end
 
-     it 'has a correctly formatted request url' do
+    it 'has a correctly formatted request url' do
       expect(subject.request.last_uri.to_s).to eq 'https://api.cordial.io/v1/contacts'
-     end
+    end
 
-     it 'has the correct payload' do
-       expect(subject.request.raw_body).to eq 'channels[email][address]=cordial%40example.com&first_name=Cordial'
-     end
+    it 'has the correct payload' do
+      expect(subject.request.raw_body).to eq 'channels[email][address]=cordial%40example.com&first_name=Cordial'
+    end
   end
-end
 

--- a/spec/cordial/contacts_spec.rb
+++ b/spec/cordial/contacts_spec.rb
@@ -27,3 +27,12 @@ RSpec.describe Cordial::Contacts do
     end
   end
 
+  describe '#unsubscribe' do
+    subject { described_class.unsubscribe(email: email) }
+
+    it 'has a correctly formatted request url' do
+      unsubscribe_url = 'https://api.cordial.io/v1/contacts/cordial@example.com/unsubscribe/email'
+      expect(subject.request.last_uri.to_s).to eq unsubscribe_url
+    end
+  end
+end


### PR DESCRIPTION
What does this change?
----

This Adds an unsubscribe method

Why are you changing that?
----

To give support to unsubscribe users from Cordial

How did you accomplish this change?
----

- Adding a put request to the Cordia API with the required information.

Merge/Deploy Checklist
----

- [ ] It has been reviewed and accepted.

How do you manually test this?
----

1. Create a client instance
2. Create a new subscription
3. Call the unsubscribe method
4. Call the find method and verify that `"subscribeStatus"` is  `"unsubscribed"` 