### PR TITLE
Add compact Hash method

### DIFF
--- a/lib/cordial.rb
+++ b/lib/cordial.rb
@@ -1,4 +1,5 @@
 require "httparty"
+require "utils/compact"
 require "cordial/version"
 require "cordial/client"
 require "cordial/contacts"

--- a/lib/utils/compact.rb
+++ b/lib/utils/compact.rb
@@ -1,0 +1,7 @@
+class Hash
+  unless Hash.instance_methods(false).include?(:compact)
+    def compact
+      select { |_, value| !value.nil? }
+    end
+  end
+end

--- a/spec/utils/compact_spec.rb
+++ b/spec/utils/compact_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Hash do
+  describe '#compact' do
+    it { expect({ a: 'a', b: nil }.compact).to eq({ a: 'a' }) }
+  end
+end


### PR DESCRIPTION
What does this change?
----

This Adds an implementation of the compact hash method to give support on versions lower than Ruby 2.4.0

Why are you changing that?
----

We want to give support to versions previous to 2.4.0

How did you accomplish this change?
----

- Adding a util Hash class with the `compact` method

How do you manually test this?
----

run `bin/console` in a ruby `2.3.x version` bash/zsh/other session, and run `{ a: 'a', b: nil }.compact` this should return `{ a: 'a' }`