### PR TITLE
Feature/orders sync

### DIFF
--- a/lib/cordial.rb
+++ b/lib/cordial.rb
@@ -4,6 +4,7 @@ require "cordial/version"
 require "cordial/client"
 require "cordial/contacts"
 require "cordial/products"
+require "cordial/orders"
 
 module Cordial
   class << self

--- a/lib/cordial/orders.rb
+++ b/lib/cordial/orders.rb
@@ -1,0 +1,65 @@
+module Cordial
+  # Wraps all interaction with the Order resource.
+  # @see https://api.cordial.io/docs/v1/#!/orders
+  class Orders
+    include ::HTTParty
+    extend Client
+
+    # Find an order
+    # @example Usage
+    #  Cordial::Orders.find(id: 1)
+    # @example Response when the order was found
+    # {
+    #   "_id"=>"5b3a774a2cab4e1a59d0cc6d",
+    #   "orderID"=>"1",
+    #   "purchaseDate"=>"2015-01-10T01:47:43+0000",
+    #   "items"=>[
+    #     {
+    #       "productID"=>"1",
+    #       "sku"=>"123",
+    #       "name"=>"Test product",
+    #       "attr"=>{
+    #         "color"=>"blue",
+    #         "size"=>"L"
+    #        },
+    #       "amount"=>0
+    #     }
+    #   ],
+    #   "cID"=>"5aea409bbb3dc2f9bc27158f",
+    #   "totalAmount"=>0
+    # }
+    #
+    # @example Response when the order was not found.
+    #  {"error"=>true, "message"=>"record not found"}
+    def self.find(id:)
+      client.get("/orders/#{id}")
+    end
+
+    # Create a new order.
+    # Posting more than one time the same "orderID" name will generate an error.
+    #
+    # @example Usage.
+    # Cordial::Orders.create(
+    #   id: 1,
+    #   email: 'cordial@example.com',
+    #   purchase_date: '2015-01-09 17:47:43',
+    #   items: [{productID: '1',
+    #            sku: '123',
+    #            name: 'Test product',
+    #            attr: { color: 'blue', size: 'L' }}])
+    # @example response whe the orderID is not on cordial
+    # {"success"=>true}
+    #
+    # @example Response when orderID already exist on cordial.
+    # {"error"=>true, "messages"=>"ID must be unique"}
+    def self.create(id:, email:, purchase_date:, items:)
+      client.post('/orders',
+                  body: {
+                    orderID: id,
+                    email: email,
+                    purchaseDate: purchase_date,
+                    items: items
+                  }.to_json)
+    end
+  end
+end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end

--- a/spec/cordial/orders_spec.rb
+++ b/spec/cordial/orders_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe Cordial::Orders do
+  let(:order_id) { '33451' }
+  let(:email) { 'cordial@example.com' }
+  let(:purchase_date) { '2018-07-02 13:19:00' }
+  let(:items) do
+    [
+      {
+        productID: '1',
+        sku: '123',
+        name: 'Test Product 1',
+        attr: {
+          color: 'blue',
+          size: 'L'
+        }
+      }
+    ]
+  end
+
+  describe '#find' do
+    subject { described_class.find(id: order_id) }
+
+    it 'has a correctly formatted request url' do
+      expect(subject.request.last_uri.to_s).to eq 'https://api.cordial.io/v1/orders/33451'
+    end
+  end
+
+  describe '#create' do
+    subject do
+      described_class.create(id: order_id,
+                             email: email,
+                             purchase_date: purchase_date,
+                             items: items)
+    end
+
+    it 'has a correctly formatted request url' do
+      expect(subject.request.last_uri.to_s).to eq 'https://api.cordial.io/v1/orders'
+    end
+
+    it 'has the correct payload' do
+      payload = '{"orderID":"33451","email":"cordial@example.com","purchaseDate":"2018-07-02 13:19:00","items":[{"productID":"1","sku":"123","name":"Test Product 1","attr":{"color":"blue","size":"L"}}]}'
+
+      expect(subject.request.raw_body).to eq payload
+    end
+  end
+end


### PR DESCRIPTION
What does this change?
----

This Adds find and create order methods

Why are you changing that?
----

To give support to find and create orders

How did you accomplish this change?
----

Adding a get and post requests to the Cordia API with the required information.

How do you manually test this?
----

## create
1. `items = [{productID: '1', sku: '123', name: 'Test product', attr: { color: 'blue', size: 'L' }}]` 
2. `Cordial::Orders.create(id: 1, email: 'juan.ruiz@magmalabs.io', purchase_date: '2015-01-09 17:47:43', items: items)`

## find
1. `Cordial::Orders.find(id: 1)`