### PR TITLE
Add linkID and mcID in order create

### DIFF
--- a/lib/cordial/orders.rb
+++ b/lib/cordial/orders.rb
@@ -42,6 +42,8 @@ module Cordial
     # Cordial::Orders.create(
     #   id: 1,
     #   email: 'cordial@example.com',
+    #   link_id: '123456',
+    #   mc_id: '645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1',
     #   purchase_date: '2015-01-09 17:47:43',
     #   items: [{productID: '1',
     #            sku: '123',
@@ -52,14 +54,18 @@ module Cordial
     #
     # @example Response when orderID already exist on cordial.
     # {"error"=>true, "messages"=>"ID must be unique"}
-    def self.create(id:, email:, purchase_date:, items:)
-      client.post('/orders',
-                  body: {
-                    orderID: id,
-                    email: email,
-                    purchaseDate: purchase_date,
-                    items: items
-                  }.to_json)
+    def self.create(id:, email:, purchase_date:, items:, link_id: '', mc_id: '')
+      body = {
+        orderID: id,
+        email: email,
+        purchaseDate: purchase_date,
+        items: items
+      }
+
+      body[:linkID] = link_id unless link_id.empty?
+      body[:mcID] = mc_id unless mc_id.empty?
+
+      client.post('/orders', body: body.to_json)
     end
   end
 end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
What does this change?
----
This adds support for linkID and mcID in order creation

Why are you changing that?
----
we want to support this fields.

How did you accomplish this change?
----
adding the fields to the body object. I didn't add a test. the tests will be rewritten in #16

Merge/Deploy Checklist
----

- [ ] It has been reviewed and accepted.

How do you manually test this?
----

```
./bin/console

items = [{productID: '1', sku: '123', name: 'Test product', attr: { color: 'blue', size: 'L' }}]

Cordial::Orders.create(id: 12, email: 'juan.ruiz@magmalabs.io', purchase_date: '2015-01-09 17:47:43', items: items, link_id: '123456', mc_id: '645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1')
```