### PR TITLE
Feature/update unsubscribe method

### DIFF
--- a/lib/cordial/contacts.rb
+++ b/lib/cordial/contacts.rb
@@ -63,14 +63,38 @@ module Cordial
 
     # Unsubscribe a contact.
     #
-    # @param channel [String] The channel to unsubscribe, defaults to `email`
+    # @param channel [String] The channel to unsubscribe`
     # @see https://support.cordial.com/hc/en-us/articles/115001319432-Channels-Overview
-    # @example Usage. Default channel.
+    # @param mc_id [String] The Message Contact ID
+    # @see https://support.cordial.com/hc/en-us/articles/115005855508-System-Variables
+    # @example Usage. Default without channel.
     #  Cordial::Contacts.unsubscribe(
     #    email: 'hello@world.earth'
     #  )
-    def self.unsubscribe(email:, channel: 'email')
-      client.put("/contacts/#{email}/unsubscribe/#{channel}")
+    #
+    # @example Usage. with channel and mcID.
+    #  Cordial::Contacts.unsubscribe(
+    #    email: 'hello@world.earth',
+    #    channel: 'email'
+    #    mc_id: '645:5b6a9f26esb828b63c2a7946:ot:8ama709bbb3dc2f9bc27158f:1'
+    #  )
+    def self.unsubscribe(email:, channel: '', mc_id: '')
+      if channel.empty? && mc_id.empty?
+        url = "/contacts/#{email}"
+        body = {
+          channels: {
+            email: {
+              address: email,
+              subscribeStatus: 'unsubscribed'
+            }
+          }
+        }
+      else
+        url = "/contacts/#{email}/unsubscribe/#{channel}"
+        body = { mcID: mc_id }
+      end
+
+      client.put(url, body: body.to_json)
     end
   end
 end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.6'.freeze
 end

--- a/spec/cordial/contacts_spec.rb
+++ b/spec/cordial/contacts_spec.rb
@@ -41,14 +41,47 @@ RSpec.describe Cordial::Contacts do
     end
   end
 
-  # TODO, revisit this test when the cordial People respond why we have
-  # an error 500 when the contact is being unsubscribed in the platform.
   describe '#unsubscribe', :vcr do
-    subject { described_class.unsubscribe(email: email) }
+    context 'when email only is passed' do
+      subject { described_class.unsubscribe(email: email) }
 
-    it 'has a correctly formatted request url' do
-      unsubscribe_url = 'https://api.cordial.io/v1/contacts/cordial@example.com/unsubscribe/email'
-      expect(subject.request.last_uri.to_s).to eq unsubscribe_url
+      it 'has a correctly formatted request url' do
+        unsubscribe_url = 'https://api.cordial.io/v1/contacts/cordial@example.com'
+        expect(subject.request.last_uri.to_s).to eq unsubscribe_url
+      end
+
+      it 'the payload contains email and unsubscribe status' do
+        payload = '{"channels":{"email":{"address":"cordial@example.com","subscribeStatus":"unsubscribed"}}}'
+
+        expect(subject.request.raw_body).to eq payload
+      end
+
+      it 'returns unsubscribed success true' do
+        response = subject
+        expect(response['success']).to eq(true)
+      end
+    end
+
+    context 'when channel and mcID are passed' do
+      subject { described_class.unsubscribe(email: email, channel: 'email', mc_id: mc_id) }
+      let(:email) { 'juan.ruiz@magmalabs.io' }
+      let(:mc_id) { '645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1' }
+
+      it 'has a correctly formatted request url' do
+        unsubscribe_url = 'https://api.cordial.io/v1/contacts/juan.ruiz@magmalabs.io/unsubscribe/email'
+        expect(subject.request.last_uri.to_s).to eq unsubscribe_url
+      end
+
+      it 'the payload contains email and unsubscribe status' do
+        payload = '{"mcID":"645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1"}'
+
+        expect(subject.request.raw_body).to eq payload
+      end
+
+      it 'returns unsubscribed success true' do
+        response = subject
+        expect(response['success']).to eq(true)
+      end
     end
   end
 end

--- a/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_channel_and_mcID_are_passed/has_a_correctly_formatted_request_url.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_channel_and_mcID_are_passed/has_a_correctly_formatted_request_url.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.cordial.io/v1/contacts/juan.ruiz@magmalabs.io/unsubscribe/email
+    body:
+      encoding: UTF-8
+      string: '{"mcID":"645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Aug 2018 23:20:16 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 23:20:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_channel_and_mcID_are_passed/returns_unsubscribed_success_true.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_channel_and_mcID_are_passed/returns_unsubscribed_success_true.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.cordial.io/v1/contacts/juan.ruiz@magmalabs.io/unsubscribe/email
+    body:
+      encoding: UTF-8
+      string: '{"mcID":"645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Aug 2018 23:20:17 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 23:20:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_channel_and_mcID_are_passed/the_payload_contains_email_and_unsubscribe_status.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_channel_and_mcID_are_passed/the_payload_contains_email_and_unsubscribe_status.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: put
-    uri: https://api.cordial.io/v1/contacts/cordial@example.com/unsubscribe/email
+    uri: https://api.cordial.io/v1/contacts/juan.ruiz@magmalabs.io/unsubscribe/email
     body:
       encoding: UTF-8
-      string: ''
+      string: '{"mcID":"645:5b6a1f26e1b829b63c2a7946:ot:5aea409bbb3dc2f9bc27158f:1"}'
     headers:
       Content-Type:
       - application/json
@@ -13,8 +13,8 @@ http_interactions:
       - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
   response:
     status:
-      code: 500
-      message: Internal Server Error
+      code: 200
+      message: OK
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -30,16 +30,16 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Aug 2018 21:53:36 GMT
+      - Mon, 13 Aug 2018 23:20:16 GMT
       Server:
       - Apache
       Content-Length:
-      - '33'
+      - '16'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"error":"an error has occurred"}'
+      string: '{"success":true}'
     http_version: 
-  recorded_at: Wed, 08 Aug 2018 21:53:36 GMT
+  recorded_at: Mon, 13 Aug 2018 23:20:17 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_email_only_is_passed/has_a_correctly_formatted_request_url.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_email_only_is_passed/has_a_correctly_formatted_request_url.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.cordial.io/v1/contacts/cordial@example.com
+    body:
+      encoding: UTF-8
+      string: '{"channels":{"email":{"address":"cordial@example.com","subscribeStatus":"unsubscribed"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Aug 2018 23:20:14 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 23:20:15 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_email_only_is_passed/returns_unsubscribed_success_true.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_email_only_is_passed/returns_unsubscribed_success_true.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.cordial.io/v1/contacts/cordial@example.com
+    body:
+      encoding: UTF-8
+      string: '{"channels":{"email":{"address":"cordial@example.com","subscribeStatus":"unsubscribed"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Aug 2018 23:20:15 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 23:20:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_email_only_is_passed/the_payload_contains_email_and_unsubscribe_status.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_unsubscribe/when_email_only_is_passed/the_payload_contains_email_and_unsubscribe_status.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.cordial.io/v1/contacts/cordial@example.com
+    body:
+      encoding: UTF-8
+      string: '{"channels":{"email":{"address":"cordial@example.com","subscribeStatus":"unsubscribed"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Aug 2018 23:20:15 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Mon, 13 Aug 2018 23:20:15 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
What does this change?
----
  This update the method to use two different approach when the user only send the email or when the user send the email, channel and mcID

Why are you changing that?
----
The unsubscribe method was returning a 500 error when mcID was not provided. 

How did you accomplish this change?
----
updating the logic to suport a regular update or an update using the unsubscribe endpoint
https://api.cordial.io/docs/v1/#/

Merge/Deploy Checklist
----

- [ ] It has been reviewed and accepted.

How do you manually test this?
----
unsubscribe an user with only the email and using, email, channel and mcID both should work

`Cordial::Contacts::unsubscribe(email: 'juan.ruiz@magmalabs.io')`

`Cordial::Contacts::unsubscribe(email: 'juan.ruiz@magmalabs.io', channel: 'email', mc_id: 'a valid mcID')`
