### PR TITLE
Add product imports endpoint

### DIFF
--- a/lib/cordial.rb
+++ b/lib/cordial.rb
@@ -5,6 +5,7 @@ require "cordial/client"
 require "cordial/contacts"
 require "cordial/products"
 require "cordial/orders"
+require "cordial/product_imports"
 
 module Cordial
   class << self

--- a/lib/cordial/product_imports.rb
+++ b/lib/cordial/product_imports.rb
@@ -1,0 +1,35 @@
+module Cordial
+  # Wraps all interaction with the Product Imports resource.
+  # @see https://api.cordial.io/docs/v1/#!/productimports
+  class ProductImports
+    include ::HTTParty
+    extend Client
+
+    # Creates an import job to batch load a file of products.
+    #
+    # @example Usage.
+    #  Cordial::ProductImports.import(
+    #    transport: "https",
+    #    url: "https://example.com/product-import.csv",
+    #    email: "example@email.com"
+    #  )
+    #
+    # @example Response when the file was imported.
+    # {"jobId"=>"f2f3f4u4j5h67687bhhjg78"}
+    #
+    # @example Response when the file was not found.
+    # {"jobId"=>{"error"=>true, "message"=>"File not found"}}
+    #
+    def self.import(transport:, url:, email:)
+      client.post('/productimports',
+                  body: {
+                    source: {
+                      transport: transport,
+                      url: url
+                    },
+                    hasHeader: true,
+                    confirmEmail: email
+                  }.to_json)
+    end
+  end
+end

--- a/spec/cordial/product_imports_spec.rb
+++ b/spec/cordial/product_imports_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.describe Cordial::ProductImports do
+  let(:transport) { 'https' }
+  let(:email) { 'test@example.com' }
+  let(:url) { 'https://example.com/product-import.csv' }
+  let(:job_id) { '12as34asfg56hj89kl' }
+
+  describe '#import', :vcr do
+    subject do
+      described_class.import(transport: transport,
+                             url: url,
+                             email: email)
+    end
+
+    it 'has the correct payload' do
+      payload = '{"source":{"transport":"https","url":"https://example.com/product-import.csv"},"hasHeader":true,"confirmEmail":"test@example.com"}'
+
+      expect(subject.request.raw_body).to eq payload
+    end
+
+    it 'returns a job id' do
+      response = subject
+
+      expect(response['jobId']).to eq job_id
+    end
+  end
+end


### PR DESCRIPTION
What does this change?
----
 This endpoint allow us to sync many products to cordial in a csv file

Why are you changing that?
----
We can sync many products at the same time and it creates a job to do that

How did you accomplish this change?
----

- Adding the `/productimports` endpoint to the Cordial API with the required information.

How do you manually test this?
----
```
Cordial::ProductImports.import(transport: "https", url: "https://example.com/product-import.csv", email: "jsmith@example.com")
```