### PR TITLE
Bug/order create nil mcid

### DIFF
--- a/lib/cordial/orders.rb
+++ b/lib/cordial/orders.rb
@@ -54,7 +54,7 @@ module Cordial
     #
     # @example Response when orderID already exist on cordial.
     # {"error"=>true, "messages"=>"ID must be unique"}
-    def self.create(id:, email:, purchase_date:, items:, link_id: '', mc_id: '')
+    def self.create(id:, email:, purchase_date:, items:, link_id: nil, mc_id: nil)
       body = {
         orderID: id,
         email: email,
@@ -62,8 +62,8 @@ module Cordial
         items: items
       }
 
-      body[:linkID] = link_id unless link_id.empty?
-      body[:mcID] = mc_id unless mc_id.empty?
+      body[:linkID] = link_id unless link_id.nil?
+      body[:mcID] = mc_id unless mc_id.nil?
 
       client.post('/orders', body: body.to_json)
     end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.6'.freeze
+  VERSION = '0.1.7'.freeze
 end


### PR DESCRIPTION
Extra validation to avoid send nil values for the `mcID` The order creation throws an exception when an invalid mcID is sent related to #17 