### PR TITLE
Add extra fields create product

### DIFF
--- a/lib/cordial/products.rb
+++ b/lib/cordial/products.rb
@@ -33,29 +33,35 @@ module Cordial
     end
 
     # Create a new product.
-    #
+    # options keyword argument is for optional parameters
+    # https://support.cordial.com/hc/en-us/articles/203886098#postProducts
     # If the product already exists it will be updated.
     # @example Usage.
     #  Cordial::Products.create(
     #    id: 1,
     #    name: 'Test Product',
-    #    price: 99.99,
-    #    variants: [{
-    #      sku: '123',
-    #      attr: {
-    #        color: 'red',
-    #        size: 'L'
-    #      }
-    #    }]
+    #    options: {
+    #      price: 99.99,
+    #      variants: [{
+    #        sku: '123',
+    #        attr: {
+    #          color: 'red',
+    #          size: 'L'
+    #        }
+    #      }],
+    #      inStock: true,
+    #      taxable: true,
+    #      enabled: true,
+    #      properties: {test_metadata: 'my test metadata'}
+    #    }
     #  )
-    def self.create(id:, name:, price:, variants:)
-      client.post('/products',
-                  body: {
-                    productID: id,
-                    productName: name,
-                    price: price,
-                    variants: variants
-                  }.to_json)
+    def self.create(id:, name:, options: {})
+      body = {
+        productID: id,
+        productName: name
+      }.merge(options).compact
+
+      client.post('/products', body: body.to_json)
     end
   end
 end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.7'.freeze
+  VERSION = '0.1.8'.freeze
 end

--- a/spec/cordial/products_spec.rb
+++ b/spec/cordial/products_spec.rb
@@ -46,12 +46,19 @@ RSpec.describe Cordial::Products do
     subject do
       described_class.create(id: product_id,
                              name: product_name,
-                             price: price,
-                             variants: variants)
+                             options: {
+                               price: price,
+                               variants: variants,
+                               inStock: true,
+                               properties: {
+                                 test_metadata_1: 'test metadata',
+                                 test_metadata_2: 'test metadata'
+                               }
+                             })
     end
 
     it 'has the correct payload' do
-      payload = '{"productID":1,"productName":"Test product","price":100,"variants":[{"sku":"skirt0912","attr":{"color":"blue","size":"8"}},{"sku":"skirt0913","attr":{"color":"red","size":"6"}}]}'
+      payload = '{"productID":1,"productName":"Test product","price":100,"variants":[{"sku":"skirt0912","attr":{"color":"blue","size":"8"}},{"sku":"skirt0913","attr":{"color":"red","size":"6"}}],"inStock":true,"properties":{"test_metadata_1":"test metadata","test_metadata_2":"test metadata"}}'
 
       expect(subject.request.raw_body).to eq payload
     end

--- a/spec/vcr_cassettes/Cordial_Products/_create/has_the_correct_payload.yml
+++ b/spec/vcr_cassettes/Cordial_Products/_create/has_the_correct_payload.yml
@@ -5,7 +5,8 @@ http_interactions:
     uri: https://api.cordial.io/v1/products
     body:
       encoding: UTF-8
-      string: '{"productID":1,"productName":"Test product","price":100,"variants":[{"sku":"skirt0912","attr":{"color":"blue","size":"8"}},{"sku":"skirt0913","attr":{"color":"red","size":"6"}}]}'
+      string: '{"productID":1,"productName":"Test product","price":100,"variants":[{"sku":"skirt0912","attr":{"color":"blue","size":"8"}},{"sku":"skirt0913","attr":{"color":"red","size":"6"}}],"inStock":true,"properties":{"test_metadata_1":"test
+        metadata","test_metadata_2":"test metadata"}}'
     headers:
       Content-Type:
       - application/json
@@ -30,7 +31,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Aug 2018 22:11:11 GMT
+      - Wed, 29 Aug 2018 20:21:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,5 +42,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"success":true,"message":"product updated"}'
     http_version: 
-  recorded_at: Wed, 08 Aug 2018 22:11:11 GMT
+  recorded_at: Wed, 29 Aug 2018 20:21:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Products/_create/returns_a_record_created/updated.yml
+++ b/spec/vcr_cassettes/Cordial_Products/_create/returns_a_record_created/updated.yml
@@ -5,7 +5,8 @@ http_interactions:
     uri: https://api.cordial.io/v1/products
     body:
       encoding: UTF-8
-      string: '{"productID":1,"productName":"Test product","price":100,"variants":[{"sku":"skirt0912","attr":{"color":"blue","size":"8"}},{"sku":"skirt0913","attr":{"color":"red","size":"6"}}]}'
+      string: '{"productID":1,"productName":"Test product","price":100,"variants":[{"sku":"skirt0912","attr":{"color":"blue","size":"8"}},{"sku":"skirt0913","attr":{"color":"red","size":"6"}}],"inStock":true,"properties":{"test_metadata_1":"test
+        metadata","test_metadata_2":"test metadata"}}'
     headers:
       Content-Type:
       - application/json
@@ -30,7 +31,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 08 Aug 2018 22:11:17 GMT
+      - Wed, 29 Aug 2018 20:21:50 GMT
       Server:
       - Apache
       Content-Length:
@@ -41,5 +42,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"success":true,"message":"product updated"}'
     http_version: 
-  recorded_at: Wed, 08 Aug 2018 22:11:17 GMT
+  recorded_at: Wed, 29 Aug 2018 20:21:50 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
What does this change?
----

This Updated the create product method to use a `options` parameter to manage all the endpoint optional parameters 

Why are you changing that?
----

To  manage more attributes in the product creation

How did you accomplish this change?
----

- *Updating the keyword arguments* 

How do you manually test this?
----
## create
1. `Cordial::Products.create(id: 1, name: 'Test Product',options: { price: 9.99, variants: [{sku: '123', attr: {color: 'red', size: 'L'}}], inStock: true, taxable: true, enabled: true, properties: {test: 'my test'}})`

## find
1. `Cordial::Products.find(id: 1)`