### PR TITLE
Feature/Add Automation templates post endpoint

### DIFF
--- a/lib/cordial.rb
+++ b/lib/cordial.rb
@@ -5,6 +5,7 @@ require "cordial/client"
 require "cordial/contacts"
 require "cordial/products"
 require "cordial/orders"
+require "cordial/automation_templates"
 
 module Cordial
   class << self

--- a/lib/cordial/automation_templates.rb
+++ b/lib/cordial/automation_templates.rb
@@ -1,0 +1,56 @@
+module Cordial
+  # Wraps all interaction with the Automation Templates resource.
+  # @see https://api.cordial.io/docs/v1/#!/automation_templates
+  class AutomationTemplates
+    include ::HTTParty
+    extend Client
+
+    # Create a new message template.
+    #
+    # @example Usage.
+    # Cordial::AutomationTemplates.create(
+    #   key: "promo_01_20_2018",
+    #   name: "promo_01_20_2018",
+    #   channel: "email",
+    #   classification: "promotional",
+    #   base_aggregation: "hourly",
+    #   headers:{
+    #     subject_email: "One Day Only Sale",
+    #     from_email: "info@example.com",
+    #     reply_email: "info@example.com",
+    #     from_description: "Promotions Team"
+    #   },
+    #   content:{
+    #     text: "<div>Hello World</div>"
+    #   }
+    # )
+    #
+    # @example successful response
+    # {"success"=>true, "message"=>"record created"}
+    #
+    # @example failed response
+    # {"error"=>true, "messages"=>"KEY must be unique"}
+    #
+    def self.create(key:, name:, channel:, classification:, base_aggregation:, headers:, content:)
+      client.post('/automationtemplates',
+                  body: {
+                    key: key,
+                    name: name,
+                    channel: channel,
+                    classification: classification,
+                    baseAggregation: base_aggregation,
+                    message: {
+                      headers: {
+                          subject: headers[:subject_email],
+                          fromEmail: headers[:from_email],
+                          replyEmail: headers[:reply_email],
+                          fromDesc: headers[:from_description]
+                      },
+                      content: {
+                          "text/html": content[:text]
+                      }
+                    }
+                  }.to_json)
+    end
+  end
+end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.8'.freeze
+  VERSION = '0.1.9'.freeze
 end

--- a/spec/cordial/automation_templates_spec.rb
+++ b/spec/cordial/automation_templates_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe Cordial::AutomationTemplates do
+  let(:key) { 'promo2018' }
+  let(:name) { 'Promo 2018' }
+  let(:channel) { 'email' }
+  let(:classification) { 'promotional' }
+  let(:base_aggregation) { 'hourly' }
+  let(:headers) do
+    {
+      subject_email: "One Day Only Sale",
+      from_email: "info@example.com",
+      reply_email: "info@example.com",
+      from_description: "Promotions Team"
+    }
+  end
+  let(:content) do
+    {
+      text: "<div>Hello World</div>"
+    }
+  end
+
+  describe '#create', :vcr do
+    subject do
+      described_class.create(
+        key: key,
+        name: name,
+        channel: channel,
+        classification: classification,
+        base_aggregation: base_aggregation,
+        headers: {
+          subject_email: headers[:subject_email],
+          from_email: headers[:from_email],
+          reply_email: headers[:reply_email],
+          from_description: headers[:from_description]
+        },
+        content: {
+          text: "<div>Hello World</div>"
+        }
+      )
+    end
+
+    it 'has the correct payload' do
+      payload = '{"key":"promo2018","name":"Promo 2018","channel":"email","classification":"promotional","baseAggregation":"hourly","message":{"headers":{"subject":"One Day Only Sale","fromEmail":"info@example.com","replyEmail":"info@example.com","fromDesc":"Promotions Team"},"content":{"text/html":"<div>Hello World</div>"}}}'
+      expect(subject.request.raw_body).to eq payload
+    end
+
+    context 'when it is a new template' do
+      let(:key) { 'new_promo' }
+      it 'returns a record created' do
+        response = subject
+        expect(response['success']).to eq(true)
+        expect(response.code).to eq(201)
+      end
+    end
+
+    context 'when it is an existing template' do
+      it 'returns a message error' do
+        response = subject
+        expect(response['error']).to eq(true)
+        expect(response.code).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_create/has_the_correct_payload.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_create/has_the_correct_payload.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates
+    body:
+      encoding: UTF-8
+      string: '{"key":"promo2018","name":"Promo 2018","channel":"email","classification":"promotional","baseAggregation":"hourly","message":{"headers":{"subject":"One
+        Day Only Sale","fromEmail":"info@example.com","replyEmail":"info@example.com","fromDesc":"Promotions
+        Team"},"content":{"text/html":"<div>Hello World</div>"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 04 Sep 2018 17:26:07 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"message":"record created"}'
+    http_version: 
+  recorded_at: Tue, 04 Sep 2018 17:26:08 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_create/when_it_is_a_new_template/returns_a_record_created.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_create/when_it_is_a_new_template/returns_a_record_created.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates
+    body:
+      encoding: UTF-8
+      string: '{"key":"new_promo","name":"Promo 2018","channel":"email","classification":"promotional","baseAggregation":"hourly","message":{"headers":{"subject":"One
+        Day Only Sale","fromEmail":"info@example.com","replyEmail":"info@example.com","fromDesc":"Promotions
+        Team"},"content":{"text/html":"<div>Hello World</div>"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 04 Sep 2018 17:26:08 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"message":"record created"}'
+    http_version: 
+  recorded_at: Tue, 04 Sep 2018 17:26:08 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_create/when_it_is_an_existing_template/returns_a_message_error.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_create/when_it_is_an_existing_template/returns_a_message_error.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates
+    body:
+      encoding: UTF-8
+      string: '{"key":"promo2018","name":"Promo 2018","channel":"email","classification":"promotional","baseAggregation":"hourly","message":{"headers":{"subject":"One
+        Day Only Sale","fromEmail":"info@example.com","replyEmail":"info@example.com","fromDesc":"Promotions
+        Team"},"content":{"text/html":"<div>Hello World</div>"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 04 Sep 2018 17:30:45 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '46'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"error":true,"messages":"KEY must be unique"}'
+    http_version: 
+  recorded_at: Tue, 04 Sep 2018 17:30:45 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
What does this change?
----
Creates a new message template in the Cordial database using the appropriate JSON body. Posting more than one time for the same template key value will generate an error. Use PUT to change or
update template data once created.

How did you accomplish this change?
----
Adding the `AutomationTemplates` class and its create method for the post endpoint

Merge/Deploy Checklist
----
- [ ] It has been reviewed and accepted.

How do you manually test this?
----
Execute this on console
```
Cordial::AutomationTemplates.create(
       key: "promo_01_20_2018",
       name: "promo_01_20_2018",
       channel: "email",
       classification: "promotional",
       base: "hourly",
       subject: "One Day Only Sale",
       from: "info@example.com",
       reply: "info@example.com",
       description: "Promotions Team",
       text: "<div>Hello World</div>"
     )
```
