### PR TITLE
Feature/Add Automation templates send endpoint

### DIFF
--- a/lib/cordial/automation_templates.rb
+++ b/lib/cordial/automation_templates.rb
@@ -52,5 +52,44 @@ module Cordial
                     }
                   }.to_json)
     end
+
+    # Sends an automation template.
+    #
+    # @example Usage.
+    # Cordial::AutomationTemplates.send(
+    #   key: "promo_01_20_2018",
+    #   email: "user@example.com",
+    #   order: {
+    #     number: "R123456789"
+    #   }
+    # )
+    #
+    # @example successful response with unsubscribed user
+    # {"success"=>true, "message"=>"messages sent", "messagecontacts"=>[
+    #   {"accepted"=>false, "email"=>"user@example.com", "error"=>"not-subscribed"}
+    # ]}
+    #
+    # @example successful response with subscribed user
+    # {"success"=>true, "message"=>"messages sent", "messagecontacts"=>
+    #   [{"accepted"=>true,
+    #     "email"=>"user@example.com",
+    #     "mcID"=>"h123456:1a1a1a1a1a1:787457457",
+    #     "cID"=>"a1a1a1a1a1a1a1a1a1"}
+    #   ]}
+    #
+    # @example failed response
+    # {"error"=>"'/v1/automationtemplates//send' is not found."}
+    #
+    def self.send(key:, email:, **args)
+      client.post("/automationtemplates/#{key}/send",
+                  body: {
+                    to: {
+                      contact: {
+                        email: email
+                      },
+                      extVars: {}.compact.merge(args)
+                    }
+                  }.to_json)
+    end
   end
 end

--- a/lib/cordial/version.rb
+++ b/lib/cordial/version.rb
@@ -1,3 +1,3 @@
 module Cordial
-  VERSION = '0.1.9'.freeze
+  VERSION = '0.1.10'.freeze
 end

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/has_the_correct_payload.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/has_the_correct_payload.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates/promo2018/send
+    body:
+      encoding: UTF-8
+      string: '{"to":{"contact":{"email":"info@example.com"},"extVars":{"order":{"number":"R123456789"}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 07 Sep 2018 23:23:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc297813f4d2be094dad6aac176c220d61536362580; expires=Sat, 07-Sep-19
+        23:23:00 GMT; path=/; domain=.api.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 456cebb2bc03777e-LAX
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"message":"messages sent","messagecontacts":[{"accepted":false,"email":"info@example.com","error":"not-subscribed"}]}'
+    http_version: 
+  recorded_at: Fri, 07 Sep 2018 23:23:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/when_an_email_is_sent/returns_a_successful_message.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/when_an_email_is_sent/returns_a_successful_message.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates/promo2018/send
+    body:
+      encoding: UTF-8
+      string: '{"to":{"contact":{"email":"info@example.com"},"extVars":{"order":{"number":"R123456789"}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 07 Sep 2018 23:23:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d623521c8438889479277250ffddb58a21536362582; expires=Sat, 07-Sep-19
+        23:23:02 GMT; path=/; domain=.api.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 456cebba3db99973-LAX
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"message":"messages sent","messagecontacts":[{"accepted":false,"email":"info@example.com","error":"not-subscribed"}]}'
+    http_version: 
+  recorded_at: Fri, 07 Sep 2018 23:23:02 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/when_the_key_is_empty/returns_a_message_error.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/when_the_key_is_empty/returns_a_message_error.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates//send
+    body:
+      encoding: UTF-8
+      string: '{"to":{"contact":{"email":"info@example.com"},"extVars":{"order":{"number":"R123456789"}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Fri, 07 Sep 2018 23:23:02 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '61'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d13ca240d048b9505cbbe549b9eff3a0e1536362582; expires=Sat, 07-Sep-19
+        23:23:02 GMT; path=/; domain=.api.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 456cebbd6b3f99bb-LAX
+    body:
+      encoding: UTF-8
+      string: '{"error":"''\/v1\/automationtemplates\/\/send'' is not found."}'
+    http_version: 
+  recorded_at: Fri, 07 Sep 2018 23:23:02 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/when_the_key_is_not_found/returns_a_message_error.yml
+++ b/spec/vcr_cassettes/Cordial_AutomationTemplates/_send/when_the_key_is_not_found/returns_a_message_error.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/automationtemplates/promo/send
+    body:
+      encoding: UTF-8
+      string: '{"to":{"contact":{"email":"info@example.com"},"extVars":{"order":{"number":"R123456789"}}}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Fri, 07 Sep 2018 23:23:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '33'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=da72b108fed70e996df98d1ebb37ad62b1536362582; expires=Sat, 07-Sep-19
+        23:23:02 GMT; path=/; domain=.api.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 456cebbf9a4e9979-LAX
+    body:
+      encoding: UTF-8
+      string: '{"error":"an error has occurred"}'
+    http_version: 
+  recorded_at: Fri, 07 Sep 2018 23:23:03 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
What does this change?
----
Sends an email using the automation templates created so the endpoint
requires the key and the email also some args can be added like
optional data. 

How did you accomplish this change?
----
Adding the `send` method

Merge/Deploy Checklist
----
- [ ] It has been reviewed and accepted.

How do you manually test this?
----
Execute this on console
```
Cordial::AutomationTemplates.send(
      key: "promo_01_20_2018",
      email: "user@example.com",
      order: {
        number: "R123456789"
      }
)
```