### PR TITLE
Add cart and contactactivities endpoints

### DIFF
--- a/lib/cordial.rb
+++ b/lib/cordial.rb
@@ -10,6 +10,7 @@ require 'cordial/order'
 
 # Controllers
 require 'cordial/contacts'
+require 'cordial/contactactivities'
 require 'cordial/products'
 require 'cordial/orders'
 require 'cordial/automation_templates'

--- a/lib/cordial.rb
+++ b/lib/cordial.rb
@@ -7,6 +7,7 @@ require 'cordial/client'
 
 # Models
 require 'cordial/order'
+require 'cordial/cart'
 
 # Controllers
 require 'cordial/contacts'

--- a/lib/cordial/cart.rb
+++ b/lib/cordial/cart.rb
@@ -1,0 +1,13 @@
+module Cordial
+  class Cart < Hashie::Dash
+    property :mcID
+    property :customerID
+    property :linkID
+    property :cartID
+    property :url
+    property :expiration
+    property :cartitems
+    property :totalAmount
+    property :tax
+  end
+end

--- a/lib/cordial/contactactivities.rb
+++ b/lib/cordial/contactactivities.rb
@@ -1,0 +1,30 @@
+module Cordial
+  # Pragmatic wrapper around the orders REST Api.
+  #
+  # @see https://api.cordial.io/docs/v1/#!/contactactivities
+  class Contactactivities
+    include ::HTTParty
+    extend Client
+
+    # Get Activity list
+    # @example Usage
+    #  Cordial::Contactactivities.find({...})
+    #
+    # @return [Hash]
+    # @return [{"error"=>true, "message"=>"record not found"}]
+    def self.find(options)
+      client.get("/contactactivities", query: options)
+    end
+
+    # Add a new activity
+    #
+    # @example Usage.
+    #   Cordial::Contactactivities.create({...})
+    #
+    # @return [{"success"=>true}]
+    # @return [{"error"=>true, "messages"=>"..."}]
+    def self.create(options)
+      client.post("/contactactivities", body: options.to_json)
+    end
+  end
+end

--- a/lib/cordial/contacts.rb
+++ b/lib/cordial/contacts.rb
@@ -96,5 +96,17 @@ module Cordial
 
       client.put(url, body: body.to_json)
     end
+
+    # Create a new contact cart.
+    #
+    # @example Usage.
+    #   Cordial::Contacts.create_cart({...})
+    #
+    # @return [{"success"=>true}]
+    # @return [{"error"=>true, "messages"=>"..."}]
+    def self.create_cart(email, options)
+      cart = Cordial::Cart.new(options)
+      client.post("/contacts/#{email}/cart", body: cart.to_json)
+    end
   end
 end

--- a/spec/cordial/contactactivities_spec.rb
+++ b/spec/cordial/contactactivities_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Cordial::Contactactivities do
+  let(:email) { 'super-random-email-address@example.com' }
+
+  describe '#find', :vcr do
+    subject { described_class.find(email: email) }
+
+    context 'when record exists' do
+      it 'provides a list of activity' do
+        expect(subject.count).to be > 1
+      end
+    end
+
+    context 'when record does not exists' do
+      let(:email) { 'an-email-that-does-not-exists@example.com' }
+
+      it 'returns record not found response' do
+        expect(subject['message']).to eq('record not found')
+      end
+    end
+  end
+
+  describe '#create', :vcr do
+    subject { described_class.create(email: email, a: action) }
+
+    let(:action) { 'cart' }
+
+    context 'with the correct parameters' do
+      it 'creates the activity in Cordial' do
+        expect(subject['success']).to eq(true)
+      end
+    end
+
+    context 'with the wrong parameters' do
+      let(:action) { nil }
+
+      it 'does not create the activity in Cordial' do
+        expect(subject['error']).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/cordial/contacts_spec.rb
+++ b/spec/cordial/contacts_spec.rb
@@ -84,4 +84,39 @@ RSpec.describe Cordial::Contacts do
       end
     end
   end
+
+  describe '#create_cart', :vcr do
+    subject { described_class.create_cart(email, options) }
+
+    let(:cart_id) { '33451' }
+    let(:email) { 'cordial@example.com' }
+    let(:cartitems) do
+      [
+        {
+          productID: '1',
+          sku: '123',
+          name: 'Test Product 1',
+          category: 'Test Category',
+          attr: {
+            color: 'blue',
+            size: 'L'
+          }
+        }
+      ]
+    end
+
+    let(:options) do
+      {
+        customerID: email,
+        cartID: cart_id,
+        cartitems: cartitems
+      }
+    end
+
+    let(:cart_id) { '10000' }
+
+    it 'creates the cart in Cordial' do
+      expect(subject['success']).to eq(true)
+    end
+  end
 end

--- a/spec/vcr_cassettes/Cordial_Contactactivities/_create/with_the_correct_parameters/creates_the_activity_in_Cordial.yml
+++ b/spec/vcr_cassettes/Cordial_Contactactivities/_create/with_the_correct_parameters/creates_the_activity_in_Cordial.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/contactactivities
+    body:
+      encoding: UTF-8
+      string: '{"email":"super-random-email-address@example.com","a":"cart"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 15 Jul 2019 14:46:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd6f72d15ed49d7b4fe9d223d353889e21563201996; expires=Tue, 14-Jul-20
+        14:46:36 GMT; path=/; domain=.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Accept-Ranges:
+      - bytes
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4f6c86de5c5bcd22-FCO
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Mon, 15 Jul 2019 14:46:36 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contactactivities/_create/with_the_wrong_parameters/does_not_create_the_activity_in_Cordial.yml
+++ b/spec/vcr_cassettes/Cordial_Contactactivities/_create/with_the_wrong_parameters/does_not_create_the_activity_in_Cordial.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/contactactivities
+    body:
+      encoding: UTF-8
+      string: '{"email":"super-random-email-address@example.com","a":null}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Mon, 15 Jul 2019 14:46:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '81'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d9e0a5b5de9201cb813d8f8fe28aa4d5b1563201997; expires=Tue, 14-Jul-20
+        14:46:37 GMT; path=/; domain=.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4f6c86e18f8a6f1c-FCO
+    body:
+      encoding: UTF-8
+      string: '{"error":true,"messages":{"validationErrors":{"a":["The a field is
+        required."]}}}'
+    http_version: 
+  recorded_at: Mon, 15 Jul 2019 14:46:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contactactivities/_find/when_record_does_not_exists/returns_record_not_found_response.yml
+++ b/spec/vcr_cassettes/Cordial_Contactactivities/_find/when_record_does_not_exists/returns_record_not_found_response.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cordial.io/v1/contactactivities?email=an-email-that-does-not-exists@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 15 Jul 2019 14:46:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d5504de34d00a25dd15e100b389843aaa1563201996; expires=Tue, 14-Jul-20
+        14:46:36 GMT; path=/; domain=.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4f6c86dbbb8fcd3a-FCO
+    body:
+      encoding: UTF-8
+      string: '{"error":true,"message":"record not found"}'
+    http_version: 
+  recorded_at: Mon, 15 Jul 2019 14:46:36 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contactactivities/_find/when_record_exists/provides_a_list_of_activity.yml
+++ b/spec/vcr_cassettes/Cordial_Contactactivities/_find/when_record_exists/provides_a_list_of_activity.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cordial.io/v1/contactactivities?email=super-random-email-address@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 15 Jul 2019 14:46:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2003'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d63be7b243ca26d7d69c8f41fd16404851563201995; expires=Tue, 14-Jul-20
+        14:46:35 GMT; path=/; domain=.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Accept-Ranges:
+      - bytes
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4f6c86d83d65cd12-FCO
+    body:
+      encoding: UTF-8
+      string: '[{"cID":"5d2c816317295b2bb952c396","_id":"5d2c8524c22c29b43652e5ed","action":"cart","time":"2019-07-15T13:52:36+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c858fb125a94060e337d1","action":"cart","time":"2019-07-15T13:54:23+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c859d895e2b653b01a468","action":"cart","time":"2019-07-15T13:54:37+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c85a84daf4ee448b8a661","action":"order","time":"2019-07-15T13:54:48+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c85acc22c29346a52e328","action":"cart","time":"2019-07-15T13:54:52+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c85d7895e2b633b01a3f8","action":"cart","time":"2019-07-15T13:55:35+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c8651b125a9c064e337e6","action":"cart","time":"2019-07-15T13:57:37+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c8fac895e2bbf4101a33c","action":"cart","time":"2019-07-15T14:37:32+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c8fb1c22c299d5f52e241","action":"cart","time":"2019-07-15T14:37:37+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c9023c22c29ac4452e270","action":"cart","time":"2019-07-15T14:39:31+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c90554daf4ece49b8a56d","action":"cart","time":"2019-07-15T14:40:21+0000","email":"super-random-email-address@example.com"},{"cID":"5d2c816317295b2bb952c396","_id":"5d2c90e3895e2bcb4001a33a","action":"t","time":"2019-07-15T14:42:43+0000","email":"super-random-email-address@example.com"}]'
+    http_version: 
+  recorded_at: Mon, 15 Jul 2019 14:46:35 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Cordial_Contacts/_create_cart/creates_the_cart_in_Cordial.yml
+++ b/spec/vcr_cassettes/Cordial_Contacts/_create_cart/creates_the_cart_in_Cordial.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.cordial.io/v1/contacts/cordial@example.com/cart
+    body:
+      encoding: UTF-8
+      string: '{"customerID":"cordial@example.com","cartID":"10000","cartitems":[{"productID":"1","sku":"123","name":"Test
+        Product 1","category":"Test Category","attr":{"color":"blue","size":"L"}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic NWFjMmEwMzI0ZThiNjYwYTUzOGI0NTY4LVBPdDRiUWdPRWdPMnBQc2dYSjhRd1JRMVhxTzNnQVZZOg==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Jul 2019 14:35:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '16'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d2c44a9446014fc02f7b2e850ac37c0f91563287720; expires=Wed, 15-Jul-20
+        14:35:20 GMT; path=/; domain=.cordial.io; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - Cordial-AccountKey,x-requested-with, Content-Type, origin, authorization,
+        accept, client-security-token, host, date, cookie, cookie2, cordial-accountid
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "://"
+      Access-Control-Max-Age:
+      - '60'
+      Accept-Ranges:
+      - bytes
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4f74b3ba2d8d6f4c-FCO
+    body:
+      encoding: UTF-8
+      string: '{"success":true}'
+    http_version: 
+  recorded_at: Tue, 16 Jul 2019 14:35:20 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
This PR implements these endpoints:

`GET /v1/contactactivities`
`POST /v1/contactactivities`
`POST /v1/contacts/{primary_key}/cart`

With these, the users have the ability to use the `Abandoned Cart Message` feature described here
https://support.cordial.com/hc/en-us/articles/228021788-Abandoned-Cart-Message